### PR TITLE
Sort tlsroutes to prevent envoy from draining filter chains

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -527,6 +528,11 @@ func (t *Translator) processHTTPRouteParentRefListener(route RouteContext, route
 
 func (t *Translator) ProcessTLSRoutes(tlsRoutes []*v1alpha2.TLSRoute, gateways []*GatewayContext, resources *Resources, xdsIR XdsIRMap) []*TLSRouteContext {
 	var relevantTLSRoutes []*TLSRouteContext
+
+	// Sort by creation timestamp to ensure we always process routes in the same order.
+	slices.SortFunc(tlsRoutes, func(a, b *v1alpha2.TLSRoute) bool {
+		return a.CreationTimestamp.Before(&b.CreationTimestamp)
+	})
 
 	for _, tls := range tlsRoutes {
 		if tls == nil {

--- a/internal/gatewayapi/testdata/tlsroute-ordered.in.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-ordered.in.yaml
@@ -1,0 +1,60 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+    creationTimestamp: "2023-01-01T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "foo.com"
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-2
+    creationTimestamp: "2023-01-02T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "bar.com"
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: default
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080

--- a/internal/gatewayapi/testdata/tlsroute-ordered.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-ordered.out.yaml
@@ -1,0 +1,135 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: tls
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: TLSRoute
+      attachedRoutes: 2 
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Sending translated listener configuration to the data plane
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Listener has been successfully translated
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+    creationTimestamp: "2023-01-01T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - foo.com
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Resolved all the Object references for the Route
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-2
+    creationTimestamp: "2023-01-02T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - bar.com
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Resolved all the Object references for the Route
+xdsIR:
+  envoy-gateway-gateway-1:
+    tcp:
+    - name: envoy-gateway-gateway-1-tls-tlsroute-1
+      address: 0.0.0.0
+      port: 10091
+      tls:
+        snis:
+        - foo.com
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+    - name: envoy-gateway-gateway-1-tls-tlsroute-2
+      address: 0.0.0.0
+      port: 10091
+      tls:
+        snis:
+        - bar.com
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1       
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+      name: envoy-gateway-gateway-1
+
+      listeners:
+      - address: ""
+        ports:
+        - name: tls
+          protocol: "TLS"
+          servicePort: 91
+          containerPort: 10091

--- a/internal/gatewayapi/testdata/tlsroute-unordered.in.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-unordered.in.yaml
@@ -1,0 +1,60 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-2
+    creationTimestamp: "2023-01-02T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "bar.com"
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+    creationTimestamp: "2023-01-01T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "foo.com"
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: default
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080

--- a/internal/gatewayapi/testdata/tlsroute-unordered.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-unordered.out.yaml
@@ -1,0 +1,135 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: tls
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: TLSRoute
+      attachedRoutes: 2 
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Sending translated listener configuration to the data plane
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Listener has been successfully translated
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+    creationTimestamp: "2023-01-01T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - foo.com
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Resolved all the Object references for the Route
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-2
+    creationTimestamp: "2023-01-02T00:00:00Z"
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - bar.com
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Resolved all the Object references for the Route
+xdsIR:
+  envoy-gateway-gateway-1:
+    tcp:
+    - name: envoy-gateway-gateway-1-tls-tlsroute-1
+      address: 0.0.0.0
+      port: 10091
+      tls:
+        snis:
+        - foo.com
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+    - name: envoy-gateway-gateway-1-tls-tlsroute-2
+      address: 0.0.0.0
+      port: 10091
+      tls:
+        snis:
+        - bar.com
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1       
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+      name: envoy-gateway-gateway-1
+
+      listeners:
+      - address: ""
+        ports:
+        - name: tls
+          protocol: "TLS"
+          servicePort: 91
+          containerPort: 10091


### PR DESCRIPTION
TLSRoutes are sorted by .metadata.creationTimestamp which ensures the same order every time. This prevents the controller from sending a re-ordered list which leads to envoy draining connections.