### PR TITLE
Differentiate between tcp listener and tcp route names

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -479,7 +479,7 @@
 									"@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
 								}
 							}],
-							"name": "default-eg-tls-passthrough-backend"
+							"name": "default-eg-tls-passthrough"
 						}
 					}
 				}, {
@@ -521,7 +521,7 @@
 									}
 								}]
 							}],
-							"name": "default-eg-tcp-backend"
+							"name": "default-eg-tcp"
 						}
 					}
 				}, {

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -326,7 +326,7 @@ xds:
             - name: envoy.filters.listener.tls_inspector
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-            name: default-eg-tls-passthrough-backend
+            name: default-eg-tls-passthrough
       - activeState:
           listener:
             '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -355,7 +355,7 @@ xds:
                       path: /dev/stdout
                   cluster: default-eg-tcp-backend
                   statPrefix: tcp
-            name: default-eg-tcp-backend
+            name: default-eg-tcp
       - activeState:
           listener:
             '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -119,7 +119,7 @@ xds:
           - name: envoy.filters.listener.tls_inspector
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-          name: default-eg-tls-passthrough-backend
+          name: default-eg-tls-passthrough
     - activeState:
         listener:
           '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -148,7 +148,7 @@ xds:
                     path: /dev/stdout
                 cluster: default-eg-tcp-backend
                 statPrefix: tcp
-          name: default-eg-tcp-backend
+          name: default-eg-tcp
     - activeState:
         listener:
           '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -393,11 +393,15 @@ func irHTTPListenerName(listener *ListenerContext) string {
 	return fmt.Sprintf("%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name)
 }
 
-func irTLSListenerName(listener *ListenerContext, tlsRoute *TLSRouteContext) string {
+func irTLSRouteName(listener *ListenerContext, tlsRoute *TLSRouteContext) string {
 	return fmt.Sprintf("%s-%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, tlsRoute.Name)
 }
 
-func irTCPListenerName(listener *ListenerContext, tcpRoute *TCPRouteContext) string {
+func irTCPListenerName(listener *ListenerContext) string {
+	return fmt.Sprintf("%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name)
+}
+
+func irTCPRouteName(listener *ListenerContext, tcpRoute *TCPRouteContext) string {
 	return fmt.Sprintf("%s-%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, tcpRoute.Name)
 }
 

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -621,9 +621,10 @@ func (t *Translator) processTLSRouteParentRefs(tlsRoute *TLSRouteContext, resour
 			// Create the TCP Listener while parsing the TLSRoute since
 			// the listener directly links to a routeDestination.
 			irListener := &ir.TCPListener{
-				Name:    irTLSListenerName(listener, tlsRoute),
-				Address: "0.0.0.0",
-				Port:    uint32(containerPort),
+				ListenerName: irTCPListenerName(listener),
+				RouteName:    irTLSRouteName(listener, tlsRoute),
+				Address:      "0.0.0.0",
+				Port:         uint32(containerPort),
 				TLS: &ir.TLSInspectorConfig{
 					SNIs: hosts,
 				},
@@ -903,7 +904,8 @@ func (t *Translator) processTCPRouteParentRefs(tcpRoute *TCPRouteContext, resour
 			// Create the TCP Listener while parsing the TCPRoute since
 			// the listener directly links to a routeDestination.
 			irListener := &ir.TCPListener{
-				Name:         irTCPListenerName(listener, tcpRoute),
+				ListenerName: irTCPListenerName(listener),
+				RouteName:    irTCPRouteName(listener, tcpRoute),
 				Address:      "0.0.0.0",
 				Port:         uint32(containerPort),
 				Destinations: routeDestinations,

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -141,7 +141,8 @@ xdsIR:
                 port: 8080
                 weight: 1
     tcp:
-      - name: envoy-gateway-gateway-1-tls-passthrough-tlsroute-1
+      - listenerName: envoy-gateway-gateway-1-tls-passthrough
+        routeName: envoy-gateway-gateway-1-tls-passthrough-tlsroute-1
         address: 0.0.0.0
         port: 10090
         tls:

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -89,7 +89,8 @@ tcpRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-      - name: "envoy-gateway-gateway-1-tcp-tcproute-1"
+      - listenerName: envoy-gateway-gateway-1-tcp
+        routeName: envoy-gateway-gateway-1-tcp-tcproute-1
         address: "0.0.0.0"
         port: 10162
         destinations:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-port.out.yaml
@@ -81,7 +81,8 @@ tcpRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-      - name: "envoy-gateway-gateway-1-tcp1-tcproute-1"
+      - listenerName: envoy-gateway-gateway-1-tcp1
+        routeName: envoy-gateway-gateway-1-tcp1-tcproute-1
         address: "0.0.0.0"
         port: 10162
         destinations:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -130,7 +130,8 @@ xdsIR:
           port: 8080
           weight: 1
     tcp:
-    - name: "envoy-gateway-gateway-1-tcp-tcproute-1"
+    - listenerName: envoy-gateway-gateway-1-tcp
+      routeName: envoy-gateway-gateway-1-tcp-tcproute-1
       address: "0.0.0.0"
       port: 10080
       destinations:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
@@ -113,13 +113,15 @@ tcpRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-      - name: "envoy-gateway-gateway-1-tcp1-tcproute-1"
+      - listenerName: envoy-gateway-gateway-1-tcp1
+        routeName: envoy-gateway-gateway-1-tcp1-tcproute-1
         address: "0.0.0.0"
         port: 10162
         destinations:
           - host: "7.7.7.7"
             port: 8163
-      - name: "envoy-gateway-gateway-1-tcp2-tcproute-2"
+      - listenerName: envoy-gateway-gateway-1-tcp2
+        routeName: envoy-gateway-gateway-1-tcp2-tcproute-2
         address: "0.0.0.0"
         port: 10163
         destinations:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -109,13 +109,15 @@ tcpRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-      - name: "envoy-gateway-gateway-1-tcp1-tcproute-1"
+      - listenerName: envoy-gateway-gateway-1-tcp1
+        routeName: envoy-gateway-gateway-1-tcp1-tcproute-1
         address: "0.0.0.0"
         port: 10161
         destinations:
           - host: "7.7.7.7"
             port: 8163
-      - name: "envoy-gateway-gateway-1-tcp2-tcproute-1"
+      - listenerName: envoy-gateway-gateway-1-tcp2
+        routeName: envoy-gateway-gateway-1-tcp2-tcproute-1
         address: "0.0.0.0"
         port: 10162
         destinations:

--- a/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
@@ -64,7 +64,8 @@ tlsRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-      - name: envoy-gateway-gateway-1-tls-tlsroute-1
+      - listenerName: envoy-gateway-gateway-1-tls
+        routeName: envoy-gateway-gateway-1-tls-tlsroute-1
         address: 0.0.0.0
         port: 10090
         tls:

--- a/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
@@ -95,7 +95,8 @@ tlsRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-    - name: envoy-gateway-gateway-1-tls-tlsroute-1
+    - listenerName: envoy-gateway-gateway-1-tls
+      routeName: envoy-gateway-gateway-1-tls-tlsroute-1
       address: 0.0.0.0
       port: 10091
       tls:
@@ -105,7 +106,8 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-    - name: envoy-gateway-gateway-1-tls-tlsroute-2
+    - listenerName: envoy-gateway-gateway-1-tls
+      routeName: envoy-gateway-gateway-1-tls-tlsroute-2
       address: 0.0.0.0
       port: 10091
       tls:

--- a/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -65,7 +65,8 @@ tlsRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-      - name: envoy-gateway-gateway-1-tls-tlsroute-1
+      - listenerName: envoy-gateway-gateway-1-tls
+        routeName: envoy-gateway-gateway-1-tls-tlsroute-1
         address: 0.0.0.0
         port: 10090
         tls:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -63,7 +63,8 @@ tlsRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-    - name: envoy-gateway-gateway-1-tls-tlsroute-1
+    - listenerName: envoy-gateway-gateway-1-tls
+      routeName: envoy-gateway-gateway-1-tls-tlsroute-1
       address: 0.0.0.0
       port: 10091
       tls:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -65,7 +65,8 @@ tlsRoutes:
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:
-    - name: envoy-gateway-gateway-1-tls-tlsroute-1
+    - listenerName: envoy-gateway-gateway-1-tls
+      routeName: envoy-gateway-gateway-1-tls-tlsroute-1
       address: 0.0.0.0
       port: 10091
       tls:

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -23,6 +23,7 @@ var (
 	ErrListenerPortInvalid           = errors.New("field Port specified is invalid")
 	ErrHTTPListenerHostnamesEmpty    = errors.New("field Hostnames must be specified with at least a single hostname entry")
 	ErrTCPListenerSNIsEmpty          = errors.New("field SNIs must be specified with at least a single server name entry")
+	ErrTCPListenerRouteNameEmpty     = errors.New("field RouteName must be specified")
 	ErrTLSServerCertEmpty            = errors.New("field ServerCertificate must be specified")
 	ErrTLSPrivateKey                 = errors.New("field PrivateKey must be specified")
 	ErrHTTPRouteNameEmpty            = errors.New("field Name must be specified")
@@ -86,7 +87,7 @@ func (x Xds) GetHTTPListener(name string) *HTTPListener {
 
 func (x Xds) GetTCPListener(name string) *TCPListener {
 	for _, listener := range x.TCP {
-		if listener.Name == name {
+		if listener.ListenerName == name {
 			return listener
 		}
 	}
@@ -602,8 +603,10 @@ func (s StringMatch) Validate() error {
 // TCPListener holds the TCP listener configuration.
 // +k8s:deepcopy-gen=true
 type TCPListener struct {
-	// Name of the TCPListener
-	Name string
+	// ListenerName of the TCPListener
+	ListenerName string
+	// RouteName of the tcp or tls route.
+	RouteName string
 	// Address that the listener should listen on.
 	Address string
 	// Port on which the service can be expected to be accessed by clients.
@@ -618,8 +621,11 @@ type TCPListener struct {
 // Validate the fields within the TCPListener structure
 func (h TCPListener) Validate() error {
 	var errs error
-	if h.Name == "" {
+	if h.ListenerName == "" {
 		errs = multierror.Append(errs, ErrListenerNameEmpty)
+	}
+	if h.RouteName == "" {
+		errs = multierror.Append(errs, ErrTCPListenerRouteNameEmpty)
 	}
 	if ip := net.ParseIP(h.Address); ip == nil {
 		errs = multierror.Append(errs, ErrListenerAddressInvalid)

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -66,32 +66,38 @@ var (
 
 	// TCPListener
 	happyTCPListenerTLSPassthrough = TCPListener{
-		Name:         "happy",
+		ListenerName: "happy-listener",
+		RouteName:    "happy-route",
 		Address:      "0.0.0.0",
 		Port:         80,
 		TLS:          &TLSInspectorConfig{SNIs: []string{"example.com"}},
 		Destinations: []*RouteDestination{&happyRouteDestination},
 	}
 	emptySNITCPListenerTLSPassthrough = TCPListener{
-		Name:         "empty-sni",
+		ListenerName: "empty-sni-listener",
+		RouteName:    "empty-sni-route",
 		Address:      "0.0.0.0",
 		Port:         80,
 		Destinations: []*RouteDestination{&happyRouteDestination},
 	}
 	invalidNameTCPListenerTLSPassthrough = TCPListener{
+		RouteName:    "invalid-listener-name-route",
 		Address:      "0.0.0.0",
 		Port:         80,
 		TLS:          &TLSInspectorConfig{SNIs: []string{"example.com"}},
 		Destinations: []*RouteDestination{&happyRouteDestination},
 	}
 	invalidAddrTCPListenerTLSPassthrough = TCPListener{
-		Name:         "invalid-addr",
+		ListenerName: "invalid-addr-listener",
+		RouteName:    "invalid-addr-route",
 		Address:      "1.0.0",
 		Port:         80,
 		TLS:          &TLSInspectorConfig{SNIs: []string{"example.com"}},
 		Destinations: []*RouteDestination{&happyRouteDestination},
 	}
 	invalidSNITCPListenerTLSPassthrough = TCPListener{
+		ListenerName: "invalid-sni-listener",
+		RouteName:    "invalid-sni-route",
 		Address:      "0.0.0.0",
 		Port:         80,
 		TLS:          &TLSInspectorConfig{SNIs: []string{}},

--- a/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
@@ -52,7 +52,8 @@ http:
     - host: "1.2.3.4"
       port: 50000
 tcp:
-- name: "fifth-listener"
+- listenerName: "fifth-listener"
+  routeName: "fifth-listener"
   address: "0.0.0.0"
   port: 10080
   tls:
@@ -61,7 +62,8 @@ tcp:
   destinations:
   - host: "1.2.3.4"
     port: 50000
-- name: "sixth-listener"
+- listenerName: "fifth-listener"
+  routeName: "sixth-listener"
   address: "0.0.0.0"
   port: 10080
   tls:

--- a/internal/xds/translator/testdata/in/xds-ir/multiple-simple-tcp-route-same-port.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/multiple-simple-tcp-route-same-port.yaml
@@ -1,5 +1,6 @@
 tcp:
-- name: "tcp-route-simple"
+- listenerName: "tcp"
+  routeName: "tcp-route-simple"
   address: "0.0.0.0"
   port: 10080
   destinations:
@@ -7,7 +8,8 @@ tcp:
     port: 50000
   - host: "5.6.7.8"
     port: 50001
-- name: "tcp-route-simple-1"
+- listenerName: "tcp"
+  routeName: "tcp-route-simple-1"
   address: "0.0.0.0"
   port: 10080
   destinations:
@@ -15,7 +17,8 @@ tcp:
     port: 50000
   - host: "5.6.7.8"
     port: 50001
-- name: "tcp-route-simple-2"
+- listenerName: "tcp"
+  routeName: "tcp-route-simple-2"
   address: "0.0.0.0"
   port: 10080
   destinations:
@@ -23,7 +26,8 @@ tcp:
     port: 50000
   - host: "5.6.7.8"
     port: 50001
-- name: "tcp-route-simple-3"
+- listenerName: "tcp"
+  routeName: "tcp-route-simple-3"
   address: "0.0.0.0"
   port: 10080
   destinations:
@@ -31,7 +35,8 @@ tcp:
     port: 50000
   - host: "5.6.7.8"
     port: 50001
-- name: "tcp-route-simple-4"
+- listenerName: "tcp"
+  routeName: "tcp-route-simple-4"
   address: "0.0.0.0"
   port: 10080
   destinations:

--- a/internal/xds/translator/testdata/in/xds-ir/tcp-route-complex.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tcp-route-complex.yaml
@@ -1,5 +1,6 @@
 tcp:
-- name: "tcp-route-complex"
+- listenerName: "tcp"
+  routeName: "tcp-route-complex"
   address: "0.0.0.0"
   port: 10080
   tls:

--- a/internal/xds/translator/testdata/in/xds-ir/tcp-route-simple.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tcp-route-simple.yaml
@@ -1,5 +1,6 @@
 tcp:
-- name: "tcp-route-simple"
+- listenerName: "tcp"
+  routeName: "tcp-route-simple"
   address: "0.0.0.0"
   port: 10080
   destinations:

--- a/internal/xds/translator/testdata/in/xds-ir/tcp-route-weighted-backend.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tcp-route-weighted-backend.yaml
@@ -1,5 +1,6 @@
 tcp:
-- name: "tcp-route-weighted-backend"
+- listenerName: "tcp"
+  routeName: "tcp-route-weighted-backend"
   address: "0.0.0.0"
   port: 10080
   tls:

--- a/internal/xds/translator/testdata/in/xds-ir/tls-route-passthrough.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tls-route-passthrough.yaml
@@ -1,5 +1,6 @@
 tcp:
-- name: "tls-passthrough"
+- listenerName: "tls"
+  routeName: "tls-passthrough"
   address: "0.0.0.0"
   port: 10080
   tls:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.listeners.yaml
@@ -67,4 +67,4 @@
             path: /dev/stdout
         cluster: tcp-route-simple-4
         statPrefix: tcp
-  name: tcp-route-simple
+  name: tcp

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.listeners.yaml
@@ -32,4 +32,4 @@
   - name: envoy.filters.listener.tls_inspector
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-  name: tcp-route-complex
+  name: tcp

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.listeners.yaml
@@ -23,4 +23,4 @@
             path: /dev/stdout
         cluster: tcp-route-simple
         statPrefix: tcp
-  name: tcp-route-simple
+  name: tcp

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.listeners.yaml
@@ -32,4 +32,4 @@
   - name: envoy.filters.listener.tls_inspector
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-  name: tcp-route-weighted-backend
+  name: tcp

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
@@ -30,4 +30,4 @@
   - name: envoy.filters.listener.tls_inspector
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-  name: tls-passthrough
+  name: tls

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -200,7 +200,7 @@ func processTCPListenerXdsTranslation(tCtx *types.ResourceVersionTable, tcpListe
 	for _, tcpListener := range tcpListeners {
 		// 1:1 between IR TCPListener and xDS Cluster
 		addXdsCluster(tCtx, addXdsClusterArgs{
-			name:         tcpListener.Name,
+			name:         tcpListener.RouteName,
 			destinations: tcpListener.Destinations,
 			tSocket:      nil,
 			protocol:     DefaultProtocol,
@@ -210,11 +210,11 @@ func processTCPListenerXdsTranslation(tCtx *types.ResourceVersionTable, tcpListe
 		// Search for an existing listener, if it does not exist, create one.
 		xdsListener := findXdsListener(tCtx, tcpListener.Address, tcpListener.Port, corev3.SocketAddress_TCP)
 		if xdsListener == nil {
-			xdsListener = buildXdsTCPListener(tcpListener.Name, tcpListener.Address, tcpListener.Port)
+			xdsListener = buildXdsTCPListener(tcpListener.ListenerName, tcpListener.Address, tcpListener.Port)
 			tCtx.AddXdsResource(resourcev3.ListenerType, xdsListener)
 		}
 
-		if err := addXdsTCPFilterChain(xdsListener, tcpListener, tcpListener.Name); err != nil {
+		if err := addXdsTCPFilterChain(xdsListener, tcpListener, tcpListener.RouteName); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Previously the name of the first tcp or tls route to be processed was used as the listener name. This lead to envoy draining when the tcp listener name changed which was caused routes being added/removed or routes being processed in a different order.
