### PR TITLE
Implement equal for ir.Xds to reduce number of xds updates

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -10,7 +10,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-	"sigs.k8s.io/yaml"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	extension "github.com/envoyproxy/gateway/internal/extension/types"
@@ -73,11 +72,6 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			}
 			// Translate to IR
 			result := t.Translate(val)
-
-			yamlXdsIR, _ := yaml.Marshal(&result.XdsIR)
-			r.Logger.WithValues("output", "xds-ir").Info(string(yamlXdsIR))
-			yamlInfraIR, _ := yaml.Marshal(&result.InfraIR)
-			r.Logger.WithValues("output", "infra-ir").Info(string(yamlInfraIR))
 
 			var curKeys, newKeys []string
 			// Get current IR keys

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -8,8 +8,10 @@ package ir
 import (
 	"errors"
 	"net"
+	"reflect"
 
 	"github.com/tetratelabs/multierror"
+	"golang.org/x/exp/slices"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -53,6 +55,26 @@ type Xds struct {
 	TCP []*TCPListener
 	// UDP Listeners exposed by the gateway.
 	UDP []*UDPListener
+}
+
+func (x1 *Xds) Equal(x2 *Xds) bool {
+	x1 = x1.DeepCopy()
+	x1.Sort()
+	x2 = x2.DeepCopy()
+	x2.Sort()
+	return reflect.DeepEqual(x1, x2)
+}
+
+func (x *Xds) Sort() {
+	slices.SortFunc(x.HTTP, func(l1, l2 *HTTPListener) bool {
+		return l1.Name < l2.Name
+	})
+	slices.SortFunc(x.TCP, func(l1, l2 *TCPListener) bool {
+		return l1.ListenerName+l1.RouteName < l2.ListenerName+l2.RouteName
+	})
+	slices.SortFunc(x.UDP, func(l1, l2 *UDPListener) bool {
+		return l1.Name < l2.Name
+	})
 }
 
 // Validate the fields within the Xds structure.

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -57,15 +57,17 @@ type Xds struct {
 	UDP []*UDPListener
 }
 
+// Equal implements the Comparable interface used by watchable.DeepEqual to skip unnecessary updates.
 func (x1 *Xds) Equal(x2 *Xds) bool {
 	x1 = x1.DeepCopy()
-	x1.Sort()
+	x1.sort()
 	x2 = x2.DeepCopy()
-	x2.Sort()
+	x2.sort()
 	return reflect.DeepEqual(x1, x2)
 }
 
-func (x *Xds) Sort() {
+// sort ensures the listeners are in a consistent order.
+func (x *Xds) sort() {
 	slices.SortFunc(x.HTTP, func(l1, l2 *HTTPListener) bool {
 		return l1.Name < l2.Name
 	})


### PR DESCRIPTION
There is a watchable map used to propagate k8s resource changes to xds changes pushed to envoy. Currently any resync  of a resource triggers a push to envoy even when nothing changes. This seems to be caused by re-ordering of the routes/listeners. This change sorts the listeners so that they are able to be checked for changes properly.

During a resync or the intial start up of the controller this should help reduce the number of updates pushed to envoy by a factor of the number of routes in the cluster.

I also deleted the conversion the conversion to yaml and logging in [internal/gatewayapi/runner/runner.go](https://github.com/gravitational/gateway/compare/teleport...gravitational:gateway:david/equal?expand=1#diff-0a92751feeb3e64824cb22f525cb08b27464d31c38cbeb309bb7f4d9e12e90c0) as this seemed to be adding a lot of noise to logs and getting quite expensive as the size of the config grows.