### PR TITLE
Compact resource reconciles into a single reconcile run

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -8,7 +8,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -66,8 +65,6 @@ type gatewayAPIReconciler struct {
 
 	resources *message.ProviderResources
 	extGVKs   []schema.GroupVersionKind
-	runC      chan struct{}
-	interval  time.Duration
 }
 
 // newGatewayAPIController
@@ -91,8 +88,6 @@ func newGatewayAPIController(mgr manager.Manager, cfg *config.Server, su status.
 		statusUpdater:   su,
 		resources:       resources,
 		extGVKs:         extGVKs,
-		runC:            make(chan struct{}, 1),
-		interval:        time.Second * 1,
 	}
 
 	c, err := controller.New("gatewayapi", mgr, controller.Options{Reconciler: r})
@@ -108,8 +103,6 @@ func newGatewayAPIController(mgr manager.Manager, cfg *config.Server, su status.
 	if err := r.watchResources(ctx, mgr, c); err != nil {
 		return err
 	}
-	go r.Run(ctx)
-
 	return nil
 }
 
@@ -144,50 +137,11 @@ func newResourceMapping() *resourceMappings {
 }
 
 func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	r.log.WithName(request.Name).Info("Scheduling reconcile for object", "namespace", request.Namespace, "name", request.Name)
-	select {
-	case r.runC <- struct{}{}:
-	default:
-	}
-	return reconcile.Result{}, nil
-}
+	r.log.WithName(request.Name).Info("reconciling object", "namespace", request.Namespace, "name", request.Name)
 
-// Run runs reconcile in a loop at a minimum interval.
-func (r *gatewayAPIReconciler) Run(ctx context.Context) {
-	t := time.NewTimer(r.interval)
-	for {
-		select {
-		case <-r.runC:
-		case <-ctx.Done():
-			return
-		}
-		r.log.Info("Running reconcile.")
-		err := r.reconcile(ctx)
-		if err != nil {
-			r.log.Error(err, "Reconcile failed to run.")
-		} else {
-
-			r.log.Info("Reconcile ran successfully.")
-		}
-		if !t.Stop() {
-			select {
-			case <-t.C:
-			default:
-			}
-		}
-		t.Reset(r.interval)
-		select {
-		case <-t.C:
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 	var gatewayClasses gwapiv1b1.GatewayClassList
 	if err := r.client.List(ctx, &gatewayClasses); err != nil {
-		return fmt.Errorf("error listing gatewayclasses: %v", err)
+		return reconcile.Result{}, fmt.Errorf("error listing gatewayclasses: %v", err)
 	}
 
 	var cc controlledClasses
@@ -215,7 +169,7 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 	acceptedGC := cc.acceptedClass()
 	if acceptedGC == nil {
 		r.log.Info("failed to find an accepted gatewayclass")
-		return nil
+		return reconcile.Result{}, nil
 	}
 
 	// Update status for all gateway classes
@@ -223,7 +177,7 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 		if err := r.gatewayClassUpdater(ctx, gc, false, string(status.ReasonOlderGatewayClassExists),
 			status.MsgOlderGatewayClassExists); err != nil {
 			r.resources.GatewayAPIResources.Delete(acceptedGC.Name)
-			return err
+			return reconcile.Result{}, err
 		}
 	}
 
@@ -232,7 +186,7 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 	resourceMap := newResourceMapping()
 
 	if err := r.processGateways(ctx, acceptedGC, resourceMap, resourceTree); err != nil {
-		return err
+		return reconcile.Result{}, err
 	}
 
 	for serviceNamespaceName := range resourceMap.allAssociatedBackendRefs {
@@ -264,9 +218,9 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 		if err != nil {
 			r.log.Error(err, "unable to find the namespace")
 			if kerrors.IsNotFound(err) {
-				return nil
+				return reconcile.Result{}, nil
 			}
-			return err
+			return reconcile.Result{}, err
 		}
 
 		resourceTree.Namespaces = append(resourceTree.Namespaces, namespace)
@@ -285,7 +239,7 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 
 	if err := r.gatewayClassUpdater(ctx, acceptedGC, true, string(gwapiv1b1.GatewayClassReasonAccepted), status.MsgValidGatewayClass); err != nil {
 		r.log.Error(err, "unable to update GatewayClass status")
-		return err
+		return reconcile.Result{}, err
 	}
 
 	// Update finalizer on the gateway class based on the resource tree.
@@ -296,14 +250,14 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 		if err := r.removeFinalizer(ctx, acceptedGC); err != nil {
 			r.log.Error(err, fmt.Sprintf("failed to remove finalizer from gatewayclass %s",
 				acceptedGC.Name))
-			return err
+			return reconcile.Result{}, err
 		}
 	} else {
 		// finalize the accepted GatewayClass.
 		if err := r.addFinalizer(ctx, acceptedGC); err != nil {
 			r.log.Error(err, fmt.Sprintf("failed adding finalizer to gatewayclass %s",
 				acceptedGC.Name))
-			return err
+			return reconcile.Result{}, err
 		}
 	}
 
@@ -312,7 +266,8 @@ func (r *gatewayAPIReconciler) reconcile(ctx context.Context) error {
 	// Store will be required to trigger a cleanup of envoy infra resources.
 	r.resources.GatewayAPIResources.Store(acceptedGC.Name, resourceTree)
 
-	return nil
+	r.log.WithName(request.Name).Info("reconciled gatewayAPI object successfully", "namespace", request.Namespace, "name", request.Name)
+	return reconcile.Result{}, nil
 }
 
 func (r *gatewayAPIReconciler) gatewayClassUpdater(ctx context.Context, gc *gwapiv1b1.GatewayClass, accepted bool, reason, msg string) error {

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -1054,7 +1054,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Only enqueue GatewayClass objects that match this Envoy Gateway's controller name.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1b1.GatewayClass{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.hasMatchingController),
 	); err != nil {
 		return err
@@ -1063,7 +1063,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Only enqueue EnvoyProxy objects that match this Envoy Gateway's GatewayClass.
 	if err := c.Watch(
 		&source.Kind{Type: &egcfgv1a1.EnvoyProxy{}},
-		handler.EnqueueRequestsFromMapFunc(r.enqueueManagedClass),
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.ResourceVersionChangedPredicate{},
 	); err != nil {
 		return err
@@ -1072,7 +1072,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Gateway CRUDs and reconcile affected GatewayClass.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1b1.Gateway{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateGatewayForReconcile),
 	); err != nil {
 		return err
@@ -1084,7 +1084,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch HTTPRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1b1.HTTPRoute{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1095,7 +1095,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch GRPCRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1a2.GRPCRoute{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1106,7 +1106,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch TLSRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1a2.TLSRoute{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1117,7 +1117,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch UDPRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1a2.UDPRoute{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1128,7 +1128,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch TCPRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1a2.TCPRoute{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1139,7 +1139,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Service CRUDs and process affected *Route objects.
 	if err := c.Watch(
 		&source.Kind{Type: &corev1.Service{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateServiceForReconcile)); err != nil {
 		return err
 	}
@@ -1147,7 +1147,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Secret CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &corev1.Secret{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateSecretForReconcile),
 	); err != nil {
 		return err
@@ -1156,7 +1156,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch ReferenceGrant CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &gwapiv1a2.ReferenceGrant{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1167,7 +1167,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Deployment CRUDs and process affected Gateways.
 	if err := c.Watch(
 		&source.Kind{Type: &appsv1.Deployment{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateDeploymentForReconcile),
 	); err != nil {
 		return err
@@ -1176,7 +1176,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch AuthenticationFilter CRUDs and enqueue associated HTTPRoute objects.
 	if err := c.Watch(
 		&source.Kind{Type: &egv1a1.AuthenticationFilter{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.httpRoutesForAuthenticationFilter)); err != nil {
 		return err
 	}
@@ -1184,7 +1184,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch RateLimitFilter CRUDs and enqueue associated HTTPRoute objects.
 	if err := c.Watch(
 		&source.Kind{Type: &egv1a1.RateLimitFilter{}},
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.httpRoutesForRateLimitFilter)); err != nil {
 		return err
 	}
@@ -1196,12 +1196,18 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(gvk)
 		if err := c.Watch(&source.Kind{Type: u},
-			&handler.EnqueueRequestForObject{}); err != nil {
+			handler.EnqueueRequestsFromMapFunc(r.enqueueClass)); err != nil {
 			return err
 		}
 		r.log.Info("Watching additional resource", "resource", gvk.String())
 	}
 	return nil
+}
+
+func (r *gatewayAPIReconciler) enqueueClass(obj client.Object) []reconcile.Request {
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Name: string(r.classController),
+	}}}
 }
 
 func (r *gatewayAPIReconciler) enqueueManagedClass(obj client.Object) []reconcile.Request {


### PR DESCRIPTION
This reduces the number of reconcile loops that need to run and restricts it to at most 1 per second.

This will prevent large cpu and memory spikes at startup and during re-syncs.