### PR TITLE
Use static clusters instead of EDS

### DIFF
--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -12,7 +12,6 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -60,15 +59,7 @@ func buildXdsCluster(routeName string, tSocket *corev3.TransportSocket, protocol
 	}
 
 	if endpointType == Static {
-		cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_EDS}
-		cluster.EdsClusterConfig = &clusterv3.Cluster_EdsClusterConfig{
-			EdsConfig: &corev3.ConfigSource{
-				ResourceApiVersion: resource.DefaultAPIVersion,
-				ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
-					Ads: &corev3.AggregatedConfigSource{},
-				},
-			},
-		}
+		cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STATIC}
 	} else {
 		cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS}
 		cluster.DnsRefreshRate = durationpb.New(30 * time.Second)

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -369,12 +369,7 @@ func findXdsCluster(tCtx *types.ResourceVersionTable, name string) *clusterv3.Cl
 func addXdsCluster(tCtx *types.ResourceVersionTable, args addXdsClusterArgs) {
 	xdsCluster := buildXdsCluster(args.name, args.tSocket, args.protocol, args.endpoint, args.circuitBreakers)
 	xdsEndpoints := buildXdsClusterLoadAssignment(args.name, args.destinations)
-	// Use EDS for static endpoints
-	if args.endpoint == Static {
-		tCtx.AddXdsResource(resourcev3.EndpointType, xdsEndpoints)
-	} else {
-		xdsCluster.LoadAssignment = xdsEndpoints
-	}
+	xdsCluster.LoadAssignment = xdsEndpoints
 	tCtx.AddXdsResource(resourcev3.ClusterType, xdsCluster)
 }
 


### PR DESCRIPTION
It appears that when a cluster is updated without a following endpoint update a cluster can lose its endpoint configuration.

I attempted to update endpoints on each cluster change to prevent this but it was still possible for the cluster update to happen after the endpoint update.

This seems related to https://github.com/envoyproxy/envoy/issues/13009

By using static clusters the endpoints are included in the cluster update. In testing this appears to resolve the issue where endpoints disappear since we no longer rely on EDS.