### PR TITLE
cd: fix ecr registry login

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,14 +30,15 @@ jobs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
       with:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: ${{ env.ECR_AWS_ROLE }}
-        mask-aws-account-id: 'no'
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+      with:
+        registry-type: public
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Build and push gateway


### PR DESCRIPTION
### Summary

Push to ECR is failing because `registry-type: public` is missing.

Also, update versions of github actions to match with `aws-quota-checker`