### PR TITLE
cd: fix public ecr region

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
       with:
-        aws-region: ${{ env.AWS_REGION }}
+        AWS_REGION: us-east-1
         role-to-assume: ${{ env.ECR_AWS_ROLE }}
     - name: Login to Amazon ECR
       id: login-ecr


### PR DESCRIPTION
Public ECR credentials should be from `us-east-1`

> Error: GetAuthorizationToken command is only supported in us-east-1.

