### PR TITLE
ci: add btrfs headers to OS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, test]
     steps:
+    - name: Install btrfs headers
+      run: sudo apt-get install libbtrfs-dev -y
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -33,6 +35,8 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
+    - name: Install btrfs headers
+      run: sudo apt-get install libbtrfs-dev -y
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Setup Go
@@ -47,6 +51,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+    - name: Install btrfs headers
+      run: sudo apt-get install libbtrfs-dev -y
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Setup Go


### PR DESCRIPTION
CI checks are failing with:

> \# github.com/containers/storage/drivers/btrfs
> Error: ../../../go/pkg/mod/github.com/containers/storage@v1.55.0/drivers/btrfs/btrfs.go:12:10: fatal error: btrfs/ioctl.h: No such file or directory
>    12 | #include <btrfs/ioctl.h>
>       |          ^~~~~~~~~~~~~~~
> compilation terminated.