### PR TITLE
teleport: annotation to enable proxyv2 from NLB (ports #28)

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -43,6 +43,10 @@ const (
 	// AnnotationUpstreamMaxConnections specifies the max upstream connections for a given
 	// route. Currently only TLSRoutes support this annotation. The value must be a valid uint32.
 	AnnotationUpstreamMaxConnections = "cloud.teleport.dev/upstream-max-connections"
+	// AnnotationGatewayDownstreamProxyProtocol enables proxy protocol for a gateways listeners.
+	// Currently this only applies to TCP listeners. The value is expected to be set to "true",
+	// case-insensitive, to enable proxy protocol. All other values will be ignored.
+	AnnotationGatewayDownstreamProxyProtocol = "cloud.teleport.dev/downstream-proxy-protocol"
 )
 
 var (
@@ -906,6 +910,11 @@ func (t *Translator) processTLSRouteParentRefs(tlsRoute *TLSRouteContext, resour
 
 				irRoute.ProxyProtocol = teleportGetProxyProtocol(tlsRoute)
 				irRoute.CircuitBreaker = teleportGetCircuitBreaker(tlsRoute)
+
+				annotations := listener.gateway.GetAnnotations()
+				if v := annotations[AnnotationGatewayDownstreamProxyProtocol]; strings.ToLower(v) == "true" {
+					irListener.EnableProxyProtocol = true
+				}
 
 				irListener.Routes = append(irListener.Routes, irRoute)
 

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-passthrough-and-proxy-protocol.in.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-passthrough-and-proxy-protocol.in.yaml
@@ -1,0 +1,33 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+      annotations:
+        cloud.teleport.dev/downstream-proxy-protocol: "true"
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: tls-passthrough
+          protocol: TLS
+          port: 443
+          tls:
+            mode: Passthrough
+          allowedRoutes:
+            namespaces:
+              from: All
+tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      namespace: default
+      name: tlsroute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - backendRefs:
+            - name: service-2
+              port: 8080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-passthrough-and-proxy-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-passthrough-and-proxy-protocol.out.yaml
@@ -1,0 +1,116 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    annotations:
+      cloud.teleport.dev/downstream-proxy-protocol: "true"
+    creationTimestamp: null
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: tls-passthrough
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: tls-passthrough
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: TLSRoute
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - address: null
+        name: envoy-gateway/gateway-1/tls-passthrough
+        ports:
+        - containerPort: 10443
+          name: tls-443
+          protocol: TLS
+          servicePort: 443
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+      name: envoy-gateway/gateway-1
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    creationTimestamp: null
+    name: tlsroute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-2
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      text:
+      - path: /dev/stdout
+    tcp:
+    - address: 0.0.0.0
+      enableProxyProtocol: true
+      name: envoy-gateway/gateway-1/tls-passthrough
+      port: 10443
+      routes:
+      - destination:
+          name: tlsroute/default/tlsroute-1/rule/-1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            protocol: HTTPS
+            weight: 1
+        name: tlsroute/default/tlsroute-1
+        tls:
+          inspector:
+            snis:
+            - '*'


### PR DESCRIPTION
This PR brings forward PR https://github.com/gravitational/gateway/pull/28 where we add a custom annotation on TLSRoutes to support client connections from the NLB using Proxy protocol v2.

Migration to equivalent capability in upstream project:
- ProxyV2 is configurable via [`ClentTrafficPolicy`](https://gateway.envoyproxy.io/docs/api/extension_types/#clienttrafficpolicy)`.spec.enableProxyProtocol `

