### PR TITLE
fix: skip reconciles on endpoint slices when endpoint routing not in use

### DIFF
--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -26,6 +26,7 @@ import (
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
+	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
 	"github.com/envoyproxy/gateway/internal/utils"
 )
 
@@ -491,7 +492,7 @@ func (r *gatewayAPIReconciler) validateEndpointSliceForReconcile(obj client.Obje
 		nsName.Name = multiClusterSvcName
 	}
 
-	if r.isRouteReferencingBackend(&nsName) {
+	if r.hasRouteWithEndpointRouting(&nsName) {
 		return true
 	}
 
@@ -513,6 +514,142 @@ func (r *gatewayAPIReconciler) validateEndpointSliceForReconcile(obj client.Obje
 		}
 	}
 
+	return false
+}
+
+// hasRouteWithEndpointRouting returns true if the backend(service and serviceImport) is referenced by any of the xRoutes
+// in the system and that route has a parent reference with EndpointRouting.
+func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.NamespacedName) bool {
+	ctx := context.Background()
+	httpRouteList := &gwapiv1.HTTPRouteList{}
+	if err := r.client.List(ctx, httpRouteList, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(backendHTTPRouteIndex, nsName.String()),
+	}); err != nil && !kerrors.IsNotFound(err) {
+		r.log.Error(err, "failed to find associated HTTPRoutes")
+		return false
+	}
+	for _, route := range httpRouteList.Items {
+		if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+			return true
+		}
+	}
+
+	if r.grpcRouteCRDExists {
+		grpcRouteList := &gwapiv1.GRPCRouteList{}
+		if err := r.client.List(ctx, grpcRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(backendGRPCRouteIndex, nsName.String()),
+		}); err != nil && !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to find associated GRPCRoutes")
+			return false
+		}
+		for _, route := range grpcRouteList.Items {
+			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+				return true
+			}
+		}
+	}
+
+	if r.tlsRouteCRDExists {
+		tlsRouteList := &gwapiv1a2.TLSRouteList{}
+		if err := r.client.List(ctx, tlsRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(backendTLSRouteIndex, nsName.String()),
+		}); err != nil && !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to find associated TLSRoutes")
+			return false
+		}
+		for _, route := range tlsRouteList.Items {
+			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+				return true
+			}
+		}
+	}
+
+	if r.tcpRouteCRDExists {
+		tcpRouteList := &gwapiv1a2.TCPRouteList{}
+		if err := r.client.List(ctx, tcpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(backendTCPRouteIndex, nsName.String()),
+		}); err != nil && !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to find associated TCPRoutes")
+			return false
+		}
+		for _, route := range tcpRouteList.Items {
+			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+				return true
+			}
+		}
+	}
+
+	if r.udpRouteCRDExists {
+		udpRouteList := &gwapiv1a2.UDPRouteList{}
+		if err := r.client.List(ctx, udpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(backendUDPRouteIndex, nsName.String()),
+		}); err != nil && !kerrors.IsNotFound(err) {
+			r.log.Error(err, "failed to find associated UDPRoutes")
+			return false
+		}
+		for _, route := range udpRouteList.Items {
+			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// hasEndpointRouting checks that the associated egv1a1.EnvoyProxy has endpoint routing.
+func (r *gatewayAPIReconciler) hasEndpointRouting(namespace string, spec gwapiv1.CommonRouteSpec) bool {
+	ctx := context.Background()
+	for _, ref := range spec.ParentRefs {
+		if ref.Kind != nil && *ref.Kind != resource.KindGateway {
+			return false
+		}
+		if ref.Namespace != nil {
+			namespace = string(*ref.Namespace)
+		}
+
+		gw := gwapiv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(ref.Name),
+				Namespace: namespace,
+			},
+		}
+		err := r.client.Get(ctx, client.ObjectKeyFromObject(&gw), &gw)
+		if err != nil {
+			r.log.Error(err, "unable to find associated gateway")
+			return false
+		}
+
+		gwc := gwapiv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: string(gw.Spec.GatewayClassName),
+			},
+		}
+		err = r.client.Get(ctx, client.ObjectKeyFromObject(&gwc), &gwc)
+		if err != nil {
+			r.log.Error(err, "unable to find associated gateway class")
+			return false
+		}
+
+		var epNs string
+		if gwc.Spec.ParametersRef.Namespace != nil {
+			epNs = string(*gwc.Spec.ParametersRef.Namespace)
+		}
+		ep := egv1a1.EnvoyProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gwc.Spec.ParametersRef.Name,
+				Namespace: epNs,
+			},
+		}
+		if err := r.client.Get(ctx, client.ObjectKeyFromObject(&ep), &ep); err != nil {
+			r.log.Error(err, "unable to find associated EnvoyProxy")
+			return false
+		}
+		rt := ep.Spec.RoutingType
+		if rt == nil || *rt == egv1a1.EndpointRoutingType {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -381,7 +381,19 @@ func TestValidateSecretForReconcile(t *testing.T) {
 // TestValidateEndpointSliceForReconcile tests the validateEndpointSliceForReconcile
 // predicate function.
 func TestValidateEndpointSliceForReconcile(t *testing.T) {
-	sampleGateway := test.GetGateway(types.NamespacedName{Namespace: "default", Name: "scheduled-status-test"}, "test-gc", 8080)
+	sampleGateway := test.GetGateway(types.NamespacedName{Name: "scheduled-status-test"}, "test-gc", 8080)
+
+	ep := test.GetEnvoyProxy(types.NamespacedName{Name: "test-ep"}, false)
+	epWithServiceRouting := ep.DeepCopy()
+	routing := egv1a1.ServiceRoutingType
+	epWithServiceRouting.Spec.RoutingType = &routing
+
+	epRef := &test.GroupKindNamespacedName{
+		Group:     gwapiv1.Group(ep.GroupVersionKind().Group),
+		Kind:      gwapiv1.Kind(ep.GroupVersionKind().Kind),
+		Namespace: gwapiv1.Namespace(ep.Namespace),
+		Name:      gwapiv1.ObjectName(ep.Name),
+	}
 
 	testCases := []struct {
 		name          string
@@ -392,7 +404,8 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 		{
 			name: "route service but no routes exist",
 			configs: []client.Object{
-				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				ep,
 				sampleGateway,
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service"),
@@ -401,7 +414,8 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 		{
 			name: "http route service routes exist, but endpointslice is associated with another service",
 			configs: []client.Object{
-				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				ep,
 				sampleGateway,
 				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
 			},
@@ -409,14 +423,26 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			expect:        false,
 		},
 		{
-			name: "http route service routes exist",
+			name: "http route service routes exist with endpoint routing",
 			configs: []client.Object{
-				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				ep,
 				sampleGateway,
 				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service"),
 			expect:        true,
+		},
+		{
+			name: "http route service routes exist with service routing",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				epWithServiceRouting,
+				sampleGateway,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service"),
+			expect:        false,
 		},
 	}
 


### PR DESCRIPTION
backport from upstream: https://github.com/envoyproxy/gateway/pull/5345