### PR TITLE
gha-cd: allow workflow_dispatch

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,9 +2,15 @@ name: cd
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+.*'
+    - 'v[0-9]+.[0-9]+.[0-9]+-*'
     branches:
     - teleport
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Tag for image and helm chart
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -20,6 +26,7 @@ jobs:
     env:
       AWS_REGION: us-east-1
       ECR_AWS_ROLE: arn:aws:iam::146628656107:role/envoy-gateway-github-action-ecr-role
+      RELEASE_VERSION: ${{ inputs.image_tag }}
     runs-on: ubuntu-latest
     needs: [verify, test]
     steps:


### PR DESCRIPTION
Lets us trigger the CD workflow with a custom tag name.

Extends the tag filter to include tagged releases. I don't expect those will get a clean tag.

https://github.com/gravitational/gateway/blob/0bd630c6216b579a9befa5d18ba002dc0f93d007/tools/make/teleport.mk#L3-L7