### PR TITLE
Service updates don't always reconcile when service routing is used.

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -1360,17 +1359,8 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// composable predicate functions - service updates do not require a reconcile when the
 	// service is not referenced by any endpoint-routed backend and ClusterIP is unchanged.
 	skipServiceUpdatesWithoutEndpointRouting := predicate.TypedFuncs[*corev1.Service]{
-		CreateFunc: func(e event.TypedCreateEvent[*corev1.Service]) bool {
-			return true
-		},
 		UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Service]) bool {
 			return r.validateServiceUpdateForReconcile(e.ObjectOld, e.ObjectNew)
-		},
-		DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Service]) bool {
-			return true
-		},
-		GenericFunc: func(e event.TypedGenericEvent[*corev1.Service]) bool {
-			return true
 		},
 	}
 
@@ -1816,7 +1806,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	return nil
 }
 
-func (r *gatewayAPIReconciler) enqueueClass(_ context.Context, o client.Object) []reconcile.Request {
+func (r *gatewayAPIReconciler) enqueueClass(_ context.Context, _ client.Object) []reconcile.Request {
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{
 		Name: string(r.classController),
 	}}}

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -403,7 +405,8 @@ func (r *gatewayAPIReconciler) processBackendRefs(ctx context.Context, gwcResour
 		switch backendRefKind {
 		case resource.KindService:
 			service := new(corev1.Service)
-			err := r.client.Get(ctx, types.NamespacedName{Namespace: string(*backendRef.Namespace), Name: string(backendRef.Name)}, service)
+			nsName := types.NamespacedName{Namespace: string(*backendRef.Namespace), Name: string(backendRef.Name)}
+			err := r.client.Get(ctx, nsName, service)
 			if err != nil {
 				r.log.Error(err, "failed to get Service", "namespace", string(*backendRef.Namespace),
 					"name", string(backendRef.Name))
@@ -413,7 +416,9 @@ func (r *gatewayAPIReconciler) processBackendRefs(ctx context.Context, gwcResour
 				r.log.Info("added Service to resource tree", "namespace", string(*backendRef.Namespace),
 					"name", string(backendRef.Name))
 			}
-			endpointSliceLabelKey = discoveryv1.LabelServiceName
+			if r.hasRouteWithEndpointRouting(&nsName) {
+				endpointSliceLabelKey = discoveryv1.LabelServiceName
+			}
 
 		case resource.KindServiceImport:
 			serviceImport := new(mcsapiv1a1.ServiceImport)
@@ -1352,12 +1357,30 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 		}
 	}
 
+	// composable predicate functions - service updates do not require a reconcile when the
+	// service is not referenced by any endpoint-routed backend and ClusterIP is unchanged.
+	skipServiceUpdatesWithoutEndpointRouting := predicate.TypedFuncs[*corev1.Service]{
+		CreateFunc: func(e event.TypedCreateEvent[*corev1.Service]) bool {
+			return true
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Service]) bool {
+			return r.validateServiceUpdateForReconcile(e.ObjectOld, e.ObjectNew)
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Service]) bool {
+			return true
+		},
+		GenericFunc: func(e event.TypedGenericEvent[*corev1.Service]) bool {
+			return true
+		},
+	}
+
 	// Watch Service CRUDs and process affected *Route objects.
-	servicePredicates := []predicate.TypedPredicate[*corev1.Service]{
+	servicePredicates := []predicate.TypedPredicate[*corev1.Service]{predicate.And[*corev1.Service](
+		skipServiceUpdatesWithoutEndpointRouting,
 		predicate.NewTypedPredicateFuncs[*corev1.Service](func(svc *corev1.Service) bool {
 			return r.validateServiceForReconcile(svc)
 		}),
-	}
+	)}
 	if r.namespaceLabel != nil {
 		servicePredicates = append(servicePredicates, predicate.NewTypedPredicateFuncs[*corev1.Service](func(svc *corev1.Service) bool {
 			return r.hasMatchingNamespaceLabels(svc)
@@ -1793,7 +1816,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	return nil
 }
 
-func (r *gatewayAPIReconciler) enqueueClass(_ context.Context, _ client.Object) []reconcile.Request {
+func (r *gatewayAPIReconciler) enqueueClass(_ context.Context, o client.Object) []reconcile.Request {
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{
 		Name: string(r.classController),
 	}}}

--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -280,55 +280,26 @@ func (r *gatewayAPIReconciler) isOIDCHMACSecret(nsName *types.NamespacedName) bo
 	return *nsName == oidcHMACSecret
 }
 
-// validateServiceOwnedByGateway returns true if the Service belongs to a Gateway.
-func (r *gatewayAPIReconciler) validateServiceOwnedByGateway(svc *corev1.Service) bool {
-	ctx := context.Background()
-	labels := svc.GetLabels()
-
-	// Check if the Service belongs to a Gateway, if so, update the Gateway status.
-	gtw := r.findOwningGateway(ctx, labels)
-	if gtw != nil {
-		r.updateGatewayStatus(gtw)
-		return true
-	}
-
-	// Merged gateways will have only this label, update status of all Gateways under found GatewayClass.
-	gcName, ok := labels[gatewayapi.OwningGatewayClassLabel]
-	if ok && r.mergeGateways.Has(gcName) {
-		if err := r.updateStatusForGatewaysUnderGatewayClass(ctx, gcName); err != nil {
-			r.log.Info("no Gateways found under GatewayClass", "name", gcName)
-			return true
-		}
-		return true
-	}
-
-	return false
-}
-
 // validateServiceUpdateForReconcile checks whether a Service update should trigger a reconcile.
 // Returns false when the backend does not have endpoint routing and the service of type clusterIP
 // does not have a new IP address.
-func (r *gatewayAPIReconciler) validateServiceUpdateForReconcile(oldObj client.Object, newObj client.Object) bool {
-	oldSvc, ok := oldObj.(*corev1.Service)
-	if !ok {
-		r.log.Info("unexpected object type, bypassing reconciliation", "object", oldObj)
-		return false
+func (r *gatewayAPIReconciler) validateServiceUpdateForReconcile(oldSvc *corev1.Service, newSvc *corev1.Service) bool {
+	ctx := context.Background()
+	labels := newSvc.GetLabels()
+	// Check if the Service belongs to a Gateway
+	gtw := r.findOwningGateway(ctx, labels)
+	if gtw != nil {
+		return true
 	}
-	newSvc, ok := newObj.(*corev1.Service)
-	if !ok {
-		r.log.Info("unexpected object type, bypassing reconciliation", "object", newObj)
-		return false
-	}
-
-	if r.validateServiceOwnedByGateway(newSvc) {
-		return false
+	// Merged gateways will have only this label
+	gcName, ok := labels[gatewayapi.OwningGatewayClassLabel]
+	if ok && r.mergeGateways.Has(gcName) {
+		return true
 	}
 
-	nsName := utils.NamespacedName(newSvc)
-	if !r.hasRouteWithEndpointRouting(&nsName) {
-		if (newSvc.Spec.Type != corev1.ServiceTypeClusterIP) || (oldSvc.Spec.Type != corev1.ServiceTypeClusterIP) || (newSvc.Spec.ClusterIP != oldSvc.Spec.ClusterIP) {
-			return false
-		}
+	if (newSvc.Spec.Type == corev1.ServiceTypeClusterIP) && (oldSvc.Spec.Type == corev1.ServiceTypeClusterIP) && (newSvc.Spec.ClusterIP == oldSvc.Spec.ClusterIP) {
+		nsName := utils.NamespacedName(newSvc)
+		return r.hasRouteWithEndpointRouting(&nsName)
 	}
 
 	return true
@@ -338,13 +309,28 @@ func (r *gatewayAPIReconciler) validateServiceUpdateForReconcile(oldObj client.O
 // if it exists, finds the Gateway's Deployment, and further updates the Gateway
 // status Ready condition. All Services are pushed for reconciliation.
 func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bool {
+	ctx := context.Background()
 	svc, ok := obj.(*corev1.Service)
 	if !ok {
 		r.log.Info("unexpected object type, bypassing reconciliation", "object", obj)
 		return false
 	}
+	labels := svc.GetLabels()
 
-	if r.validateServiceOwnedByGateway(svc) {
+	// Check if the Service belongs to a Gateway, if so, update the Gateway status.
+	gtw := r.findOwningGateway(ctx, labels)
+	if gtw != nil {
+		r.updateGatewayStatus(gtw)
+		return false
+	}
+
+	// Merged gateways will have only this label, update status of all Gateways under found GatewayClass.
+	gcName, ok := labels[gatewayapi.OwningGatewayClassLabel]
+	if ok && r.mergeGateways.Has(gcName) {
+		if err := r.updateStatusForGatewaysUnderGatewayClass(ctx, gcName); err != nil {
+			r.log.Info("no Gateways found under GatewayClass", "name", gcName)
+			return false
+		}
 		return false
 	}
 

--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -280,23 +280,16 @@ func (r *gatewayAPIReconciler) isOIDCHMACSecret(nsName *types.NamespacedName) bo
 	return *nsName == oidcHMACSecret
 }
 
-// validateServiceForReconcile tries finding the owning Gateway of the Service
-// if it exists, finds the Gateway's Deployment, and further updates the Gateway
-// status Ready condition. All Services are pushed for reconciliation.
-func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bool {
+// validateServiceOwnedByGateway returns true if the Service belongs to a Gateway.
+func (r *gatewayAPIReconciler) validateServiceOwnedByGateway(svc *corev1.Service) bool {
 	ctx := context.Background()
-	svc, ok := obj.(*corev1.Service)
-	if !ok {
-		r.log.Info("unexpected object type, bypassing reconciliation", "object", obj)
-		return false
-	}
 	labels := svc.GetLabels()
 
 	// Check if the Service belongs to a Gateway, if so, update the Gateway status.
 	gtw := r.findOwningGateway(ctx, labels)
 	if gtw != nil {
 		r.updateGatewayStatus(gtw)
-		return false
+		return true
 	}
 
 	// Merged gateways will have only this label, update status of all Gateways under found GatewayClass.
@@ -304,8 +297,54 @@ func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bo
 	if ok && r.mergeGateways.Has(gcName) {
 		if err := r.updateStatusForGatewaysUnderGatewayClass(ctx, gcName); err != nil {
 			r.log.Info("no Gateways found under GatewayClass", "name", gcName)
+			return true
+		}
+		return true
+	}
+
+	return false
+}
+
+// validateServiceUpdateForReconcile checks whether a Service update should trigger a reconcile.
+// Returns false when the backend does not have endpoint routing and the service of type clusterIP
+// does not have a new IP address.
+func (r *gatewayAPIReconciler) validateServiceUpdateForReconcile(oldObj client.Object, newObj client.Object) bool {
+	oldSvc, ok := oldObj.(*corev1.Service)
+	if !ok {
+		r.log.Info("unexpected object type, bypassing reconciliation", "object", oldObj)
+		return false
+	}
+	newSvc, ok := newObj.(*corev1.Service)
+	if !ok {
+		r.log.Info("unexpected object type, bypassing reconciliation", "object", newObj)
+		return false
+	}
+
+	if r.validateServiceOwnedByGateway(newSvc) {
+		return false
+	}
+
+	nsName := utils.NamespacedName(newSvc)
+	if !r.hasRouteWithEndpointRouting(&nsName) {
+		if (newSvc.Spec.Type != corev1.ServiceTypeClusterIP) || (oldSvc.Spec.Type != corev1.ServiceTypeClusterIP) || (newSvc.Spec.ClusterIP != oldSvc.Spec.ClusterIP) {
 			return false
 		}
+	}
+
+	return true
+}
+
+// validateServiceForReconcile tries finding the owning Gateway of the Service
+// if it exists, finds the Gateway's Deployment, and further updates the Gateway
+// status Ready condition. All Services are pushed for reconciliation.
+func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bool {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		r.log.Info("unexpected object type, bypassing reconciliation", "object", obj)
+		return false
+	}
+
+	if r.validateServiceOwnedByGateway(svc) {
 		return false
 	}
 

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -1354,7 +1354,6 @@ func TestServiceHasRouteWithEndpointRouting(t *testing.T) {
 			require.Equal(t, tc.expect, res)
 		})
 	}
-
 }
 
 func TestValidateServiceUpdateForReconcile(t *testing.T) {
@@ -1528,5 +1527,4 @@ func TestValidateServiceUpdateForReconcile(t *testing.T) {
 			require.Equal(t, tc.expect, res)
 		})
 	}
-
 }

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/logging"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes/test"
+	"github.com/envoyproxy/gateway/internal/utils"
 )
 
 // TestGatewayClassHasMatchingController tests the hasMatchingController
@@ -1264,4 +1265,268 @@ func TestValidateHTTPRouteFilerForReconcile(t *testing.T) {
 			require.Equal(t, tc.expect, res)
 		})
 	}
+}
+
+func TestServiceHasRouteWithEndpointRouting(t *testing.T) {
+	sampleGateway := test.GetGateway(types.NamespacedName{Name: "scheduled-status-test"}, "test-gc", 8080)
+
+	ep := test.GetEnvoyProxy(types.NamespacedName{Name: "test-ep"}, false)
+	epWithServiceRouting := ep.DeepCopy()
+	routing := egv1a1.ServiceRoutingType
+	epWithServiceRouting.Spec.RoutingType = &routing
+
+	epRef := &test.GroupKindNamespacedName{
+		Group:     gwapiv1.Group(ep.GroupVersionKind().Group),
+		Kind:      gwapiv1.Kind(ep.GroupVersionKind().Kind),
+		Namespace: gwapiv1.Namespace(ep.Namespace),
+		Name:      gwapiv1.ObjectName(ep.Name),
+	}
+
+	service := test.GetService(types.NamespacedName{Name: "service"}, nil, nil)
+
+	testCases := []struct {
+		name    string
+		configs []client.Object
+		service client.Object
+		expect  bool
+	}{
+		{
+			name: "service routing _ no routes exist",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+			},
+			service: service,
+			expect:  false,
+		},
+		{
+			name: "service routing _ httproute",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			service: service,
+			expect:  false,
+		},
+		{
+			name: "endpoint routing _ no routes exist",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				ep,
+			},
+			service: service,
+			expect:  false,
+		},
+		{
+			name: "endpoint routing _ httproute",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				ep,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			service: service,
+			expect:  true,
+		},
+	}
+
+	// Create the reconciler.
+	logger := logging.DefaultLogger(egv1a1.LogLevelInfo)
+
+	r := gatewayAPIReconciler{
+		classController: egv1a1.GatewayControllerName,
+		log:             logger,
+	}
+
+	for _, tc := range testCases {
+		r.client = fakeclient.NewClientBuilder().
+			WithScheme(envoygateway.GetScheme()).
+			WithObjects(tc.configs...).
+			WithIndex(&gwapiv1.HTTPRoute{}, backendHTTPRouteIndex, backendHTTPRouteIndexFunc).
+			Build()
+		t.Run(tc.name, func(t *testing.T) {
+			nsName := utils.NamespacedName(tc.service)
+			res := r.hasRouteWithEndpointRouting(&nsName)
+			require.Equal(t, tc.expect, res)
+		})
+	}
+
+}
+
+func TestValidateServiceUpdateForReconcile(t *testing.T) {
+	sampleGateway := test.GetGateway(types.NamespacedName{Name: "scheduled-status-test"}, "test-gc", 8080)
+
+	ep := test.GetEnvoyProxy(types.NamespacedName{Name: "test-ep"}, false)
+	epWithServiceRouting := ep.DeepCopy()
+	routing := egv1a1.ServiceRoutingType
+	epWithServiceRouting.Spec.RoutingType = &routing
+
+	epRef := &test.GroupKindNamespacedName{
+		Group:     gwapiv1.Group(ep.GroupVersionKind().Group),
+		Kind:      gwapiv1.Kind(ep.GroupVersionKind().Kind),
+		Namespace: gwapiv1.Namespace(ep.Namespace),
+		Name:      gwapiv1.ObjectName(ep.Name),
+	}
+
+	oldClusterIP := test.GetService(types.NamespacedName{Name: "service"}, nil, nil)
+	oldClusterIP.Spec.ClusterIP = "1.2.3.4"
+	oldClusterIP.Spec.Type = corev1.ServiceTypeClusterIP
+	oldClusterIP.Spec.Selector = map[string]string{"app": "test"}
+	newClusterIPSelectorChange := oldClusterIP.DeepCopy()
+	newClusterIPSelectorChange.Spec.Selector = map[string]string{"app": "test2"}
+	newClusterIPChange := oldClusterIP.DeepCopy()
+	newClusterIPChange.Spec.ClusterIP = "4.3.2.1"
+	oldNodePort := oldClusterIP.DeepCopy()
+	oldNodePort.Spec.Type = corev1.ServiceTypeNodePort
+
+	testCases := []struct {
+		name       string
+		configs    []client.Object
+		serviceOld *corev1.Service
+		serviceNew *corev1.Service
+		expect     bool
+	}{
+		{
+			name: "service routing _ clusterIP svc _ no routes _ no change",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: oldClusterIP,
+			expect:     false,
+		},
+		{
+			name: "service routing _ clusterIP svc _ httproute _ no change",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: oldClusterIP,
+			expect:     false,
+		},
+		{
+			name: "service routing _ nodeport svc _ no routes _ no change",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+			},
+			serviceOld: oldNodePort,
+			serviceNew: oldNodePort,
+			expect:     true,
+		},
+		{
+			name: "service routing _ nodeport svc _ httproute _ no change",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldNodePort,
+			serviceNew: oldNodePort,
+			expect:     true,
+		},
+		{
+			name: "service routing _ clusterIP svc _ httproute _ change selector",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: newClusterIPSelectorChange,
+			expect:     false,
+		},
+		{
+			name: "service routing _ clusterIP svc _ httproute _ change clusterIP",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				epWithServiceRouting,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: newClusterIPChange,
+			expect:     true,
+		},
+		{
+			name: "endpoint routing _ clusterIP svc _ no routes _ no change",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				ep,
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: oldClusterIP,
+			expect:     false,
+		},
+		{
+			name: "endpoint routing _ clusterIP svc _ httproute _ no change",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				ep,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: oldClusterIP,
+			expect:     true,
+		},
+		{
+			name: "endpoint routing _ clusterIP svc _ httproute _ change selector",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				ep,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: newClusterIPSelectorChange,
+			expect:     true,
+		},
+		{
+			name: "endpoint routing _ clusterIP svc _ httproute _ change clusterIP",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, epRef),
+				sampleGateway,
+				ep,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}, 80, ""),
+			},
+			serviceOld: oldClusterIP,
+			serviceNew: newClusterIPChange,
+			expect:     true,
+		},
+	}
+
+	// Create the reconciler.
+	logger := logging.DefaultLogger(egv1a1.LogLevelInfo)
+
+	r := gatewayAPIReconciler{
+		classController: egv1a1.GatewayControllerName,
+		log:             logger,
+	}
+
+	for _, tc := range testCases {
+		r.client = fakeclient.NewClientBuilder().
+			WithScheme(envoygateway.GetScheme()).
+			WithObjects(tc.configs...).
+			WithIndex(&gwapiv1.HTTPRoute{}, backendHTTPRouteIndex, backendHTTPRouteIndexFunc).
+			Build()
+		t.Run(tc.name, func(t *testing.T) {
+			res := r.validateServiceUpdateForReconcile(tc.serviceOld, tc.serviceNew)
+			require.Equal(t, tc.expect, res)
+		})
+	}
+
 }


### PR DESCRIPTION
This PR adds on to the behaviour change in #72.

Modifies the predicate filters on the the `service` watch so update events for services without endpoint routing will only trigger a reconcile if the cluster IP changes.

Adjusts the resource tree builder so endpoints are not collected when a service does not use endpoint routing.
