### PR TITLE
fix(internal/provider/kubernetes): query exact group version

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -2552,7 +2552,8 @@ func (r *gatewayAPIReconciler) crdExists(mgr manager.Manager, kind, groupVersion
 		return false
 	}
 	found := false
-	for _, res := range apiResourceList.APIResources {
+	for i := range apiResourceList.APIResources {
+		res := &apiResourceList.APIResources[i]
 		if res.Kind == kind {
 			found = true
 			break

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -2541,18 +2541,21 @@ func (r *gatewayAPIReconciler) crdExists(mgr manager.Manager, kind, groupVersion
 	if err != nil {
 		r.log.Error(err, "failed to create discovery client")
 	}
-	apiResourceList, err := discoveryClient.ServerPreferredResources()
+	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false
+		}
+
 		r.log.Error(err, "failed to get API resource list")
+
+		return false
 	}
 	found := false
-	for _, list := range apiResourceList {
-		for i := range list.APIResources {
-			res := &list.APIResources[i]
-			if list.GroupVersion == groupVersion && res.Kind == kind {
-				found = true
-				break
-			}
+	for _, res := range apiResourceList.APIResources {
+		if res.Kind == kind {
+			found = true
+			break
 		}
 	}
 

--- a/test/helm/gateway-addons-helm/default.out.yaml
+++ b/test/helm/gateway-addons-helm/default.out.yaml
@@ -648,6 +648,7 @@ data:
                   endpoint: 0.0.0.0:6831
                 thrift_http:
                   endpoint: 0.0.0.0:14268
+            opencensus: null
             otlp:
               protocols:
                 grpc:
@@ -10179,7 +10180,7 @@ spec:
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: gateway-addons-helm
       annotations:
-        checksum/config: 0898f7ca87563d700c35d7ea1824cd042cf93fb2f05e254d12a854aa97a5c5e5
+        checksum/config: 6adb3b32cdf74ea13067dd7baba57991ad7df001873357792a143dc450fd9dd5
     spec:
       serviceAccountName: tempo
       automountServiceAccountToken: true

--- a/test/helm/gateway-addons-helm/e2e.out.yaml
+++ b/test/helm/gateway-addons-helm/e2e.out.yaml
@@ -740,6 +740,7 @@ data:
                   endpoint: 0.0.0.0:6831
                 thrift_http:
                   endpoint: 0.0.0.0:14268
+            opencensus: null
             otlp:
               protocols:
                 grpc:
@@ -10298,7 +10299,7 @@ spec:
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: gateway-addons-helm
       annotations:
-        checksum/config: 0898f7ca87563d700c35d7ea1824cd042cf93fb2f05e254d12a854aa97a5c5e5
+        checksum/config: 6adb3b32cdf74ea13067dd7baba57991ad7df001873357792a143dc450fd9dd5
     spec:
       serviceAccountName: tempo
       automountServiceAccountToken: true


### PR DESCRIPTION
> [!NOTE]
> This fix itself will be skipped when rebased on top of v1.7.4 since v1.7.4 includes a similar change:
> https://github.com/envoyproxy/gateway/commit/09b6456a1b0bfefc4b893cff2311394519e3378d#diff-23bf3812d0ac897236b3922584793eef97a55a469cf9737d9b5290b25bb3453d

> [!NOTE]
> We haven't deployed v1.5.4-teleport.0 yet, which causes this change in argument formatting for tenant-gateway pods from v1.5.2-teleport.3. This means tenant-gateway pods will be rolled when this fix is released even though this fix itself is specific to the envoy controller.


```
    deployment.kubernetes.io/revision: "1"                    |     deployment.kubernetes.io/revision: "2"
  creationTimestamp: "2026-07-06T15:29:59Z"                   |   creationTimestamp: "2026-07-06T17:19:56Z"
  generation: 4                                               |   generation: 1
    pod-template-hash: fc9d6779f                              |     pod-template-hash: 8495cddc78
  name: envoy-gateway-system-tenant-gateway-c791e292-fc9d6779 |   name: envoy-gateway-system-tenant-gateway-c791e292-8495cddc
  resourceVersion: "119289"                                   |   resourceVersion: "119238"
  uid: 64f69f88-ea0e-4d17-b2df-4e38c5aa50f7                   |   uid: b0e6327c-c365-4d18-a22f-1df18ac018ee
  replicas: 0                                                 |   replicas: 3
      pod-template-hash: fc9d6779f                            |       pod-template-hash: 8495cddc78
        pod-template-hash: fc9d6779f                          |         pod-template-hash: 8495cddc78
        - --service-cluster gateway-system/tenant-gateway     |         - --service-cluster
        - --service-node $(ENVOY_POD_NAME)                    |         - gateway-system/tenant-gateway
                                                              >         - --service-node
                                                              >         - $(ENVOY_POD_NAME)
                                                              >         - --config-yaml
          --config-yaml admin:                                |           admin:
        - --log-level warn                                    |         - --log-level
                                                              >         - warn
        - --drain-strategy immediate                          |         - --drain-strategy
        - --component-log-level misc:error                    |         - immediate
        - --drain-time-s 300                                  |         - --component-log-level
                                                              >         - misc:error
                                                              >         - --drain-time-s
                                                              >         - "300"
  observedGeneration: 4                                       |   availableReplicas: 3
  replicas: 0                                                 |   fullyLabeledReplicas: 3
                                                              >   observedGeneration: 1
                                                              >   readyReplicas: 3
                                                              >   replicas: 3
```

---

Previously, the controller queried the preferred group version, which could result in not finding older CRDs if newer versions were deployed. If the CRD is not found then a watcher is not configured. In the case of TLSRoute then all tenant connections are dropped after being drained.

Now, query the specific group version to find the desired CRD.

For example, deploying an updated TLSRoute CRD with both v1alpha2 and v1alpha3 would result in envoy-gateway 1.5.4 in failing to find TLSRoute for v1alpha2 since only v1alpha3 is returned as the preferred version. This ultimately enables downgrading the envoy controller in the case it needs to be rolled back.

Related: https://github.com/gravitational/cloud/issues/17624

How this was verified in dev/lime:

1. Deploy updated CRDs: https://github.com/gravitational/cloud/commit/dccf406e6d43da926dd4abd2f4ea92d7f9aa7973
2. Roll envoy controller pods (with previous image)
3. envoy controller logs then report errors such as `TLSRoute CRD not found, skipping TLSRoute watch`
4. Upgrade envoy controller image with this fix
5. envoy controller then logs:

```
2026-07-06T17:19:25.542Z        INFO    provider        controller/controller.go:246    Starting EventSource    {"runner": "provider", "controller": "gatewayapi-1783358365", "source": "kind source: *v1alpha2.TLSRoute"}
```

---

How to verify in test/staging:

1. envoy-controller pods rollout and tenant connections are not impacted